### PR TITLE
Modelo del formulario de capacitación

### DIFF
--- a/app/models/cap_employee.rb
+++ b/app/models/cap_employee.rb
@@ -1,0 +1,4 @@
+class CapEmployee < ApplicationRecord
+  belongs_to :cap_result
+  validates :name, :last_name, :cuil, :cap_result_id, presence: true
+end

--- a/app/models/cap_result.rb
+++ b/app/models/cap_result.rb
@@ -2,9 +2,9 @@ class CapResult < ApplicationRecord
   # Associations
   belongs_to :task
   has_many :cap_employees
-  validates :topic, :attendees_count, :task, presence: true
+  validates :topic, :task, presence: true
 
   def valid_result?
-    attendees_count != 0 && (attendees_count.eql?cap_employees.size)
+    cap_employees.size.positive?
   end
 end

--- a/app/models/cap_result.rb
+++ b/app/models/cap_result.rb
@@ -1,0 +1,10 @@
+class CapResult < ApplicationRecord
+  # Associations
+  belongs_to :task
+  has_many :cap_employees
+  validates :topic, :attendees_count, :task, presence: true
+
+  def valid_result?
+    attendees_count != 0 && (attendees_count.eql?cap_employees.size)
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,6 @@
 class Task < ApplicationRecord
   belongs_to :visit
+  has_one :cap_result
 
   validates :status, :task_type, :visit, presence: true
   enum status: [:pending, :completed], _prefix: true
@@ -9,11 +10,38 @@ class Task < ApplicationRecord
   private
 
   def validate_values
-    return if valid_values?
+    return if valid_pending_values? && valid_completed_values?
     errors.add('invalid_task', 'Invalid completed_at for the status')
   end
 
-  def valid_values?
-    status_pending? ? completed_at.blank? : completed_at.present?
+  def valid_pending_values?
+    status_pending? ? completed_at.blank? : true
   end
+
+  def valid_completed_values?
+    status_completed? ? completed_at.present? && valid_result_values? : true
+  end
+
+  def valid_result_values?
+    cap_valid_values? && rar_valid_values? && rgrl_valid_values?
+  end
+
+  def rar_valid_values?
+    # TODO
+    task_type_rar? ? true : true
+  end
+
+  def rgrl_valid_values?
+    # TODO
+    task_type_rgrl? ? true : true
+  end
+
+  def cap_valid_values?
+    task_type_cap? ? cap_result.present? && cap_result.valid_result? : true
+  end
+
+  def complete
+
+  end
+
 end

--- a/db/migrate/20170917055242_create_cap_results.rb
+++ b/db/migrate/20170917055242_create_cap_results.rb
@@ -1,0 +1,13 @@
+class CreateCapResults < ActiveRecord::Migration[5.0]
+  def change
+    create_table :cap_results do |t|
+      t.string :topic, null: false
+      t.integer :attendees_count, null: false
+      t.string :used_materials
+      t.string :delivered_materials
+      t.references :task, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170917063219_create_cap_employees.rb
+++ b/db/migrate/20170917063219_create_cap_employees.rb
@@ -1,0 +1,14 @@
+class CreateCapEmployees < ActiveRecord::Migration[5.0]
+  def change
+    create_table :cap_employees do |t|
+      t.string :name, null: false
+      t.string :last_name, null: false
+      t.string :cuil, null: false
+      t.string :sector
+      t.references :cap_result, foreign_key: true, null: false
+
+      t.timestamps
+    end
+    add_index :cap_employees, [:cuil, :cap_result_id], unique: true
+  end
+end

--- a/db/migrate/20170917195304_delete_attendees_count_of_cap_result.rb
+++ b/db/migrate/20170917195304_delete_attendees_count_of_cap_result.rb
@@ -1,0 +1,5 @@
+class DeleteAttendeesCountOfCapResult < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :cap_results, :attendees_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170905035932) do
+ActiveRecord::Schema.define(version: 20170917063219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,29 @@ ActiveRecord::Schema.define(version: 20170905035932) do
     t.datetime "updated_at",                          null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true, using: :btree
+  end
+
+  create_table "cap_employees", force: :cascade do |t|
+    t.string   "name",          null: false
+    t.string   "last_name",     null: false
+    t.string   "cuil",          null: false
+    t.string   "sector"
+    t.integer  "cap_result_id", null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.index ["cap_result_id"], name: "index_cap_employees_on_cap_result_id", using: :btree
+    t.index ["cuil", "cap_result_id"], name: "index_cap_employees_on_cuil_and_cap_result_id", unique: true, using: :btree
+  end
+
+  create_table "cap_results", force: :cascade do |t|
+    t.string   "topic",               null: false
+    t.integer  "attendees_count",     null: false
+    t.string   "used_materials"
+    t.string   "delivered_materials"
+    t.integer  "task_id",             null: false
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
+    t.index ["task_id"], name: "index_cap_results_on_task_id", using: :btree
   end
 
   create_table "institutions", force: :cascade do |t|
@@ -123,6 +146,8 @@ ActiveRecord::Schema.define(version: 20170905035932) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "cap_employees", "cap_results"
+  add_foreign_key "cap_results", "tasks"
   add_foreign_key "institutions", "zones"
   add_foreign_key "tasks", "visits"
   add_foreign_key "users", "zones"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170917063219) do
+ActiveRecord::Schema.define(version: 20170917195304) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,7 +60,6 @@ ActiveRecord::Schema.define(version: 20170917063219) do
 
   create_table "cap_results", force: :cascade do |t|
     t.string   "topic",               null: false
-    t.integer  "attendees_count",     null: false
     t.string   "used_materials"
     t.string   "delivered_materials"
     t.integer  "task_id",             null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,10 +43,30 @@ completed_visit_another_user = Visit.create!(institution: another_institution, u
                                              status: :completed, priority: 4, to_visit_on: Date.yesterday,
                                              completed_at: Date.yesterday, observations: 'Se observa humedad en el area de trabajo')
 
+#Visits and tasks CAP
+assigned_visit_cap = Visit.create!(institution: institution, user: preventor_user, status: :assigned, priority: 9,
+                               to_visit_on: Date.today)
+pending_visit_cap = Visit.create!(institution: institution, status: :pending, priority: 8)
+assigned_visit_cap_2 = Visit.create!(institution: institution, user: preventor_user, status: :assigned, priority: 9,
+                                     to_visit_on: Date.today)
+
+completed_cap_task = Task.create!(task_type: :cap, status: :pending, visit: assigned_visit_cap )
+cap_result = CapResult.create!(task: completed_cap_task, topic: 'Optimización de Salidas de emergencia' )
+CapEmployee.create!(name:'Julian', last_name:'Alvarez', cuil:'23-12345621-6', sector: 'Seguridad e higiene', cap_result: cap_result)
+completed_cap_task.complete(DateTime.yesterday)
+
+completed_cap_task_2 = Task.create!(task_type: :cap, status: :pending, visit: assigned_visit_cap_2 )
+cap_result_2 = CapResult.create!(task: completed_cap_task_2, topic: 'Como aprobar proyecto?' )
+CapEmployee.create!(name:'Tomas', last_name:'Capuccio', cuil:'23-123235621-6', sector: '5to año utn frba', cap_result: cap_result_2)
+completed_cap_task_2.complete(DateTime.yesterday)
+
+Task.create!(task_type: :cap, status: :pending, visit: pending_visit_cap )
+
 # Tasks
 Task.create!(task_type: :rgrl, status: :pending, visit: pending_visit )
 Task.create!(task_type: :rgrl, status: :pending, visit: assigned_visit )
-Task.create!(task_type: :cap, status: :completed, completed_at:Date.yesterday,  visit: completed_visit )
+
 Task.create!(task_type: :rgrl, status: :completed, completed_at:Date.yesterday, visit: completed_visit )
 Task.create!(task_type: :rgrl, status: :completed, completed_at:Date.yesterday, visit: completed_visit_another_user )
-Task.create!(task_type: :cap, status: :completed, completed_at:Date.yesterday, visit: completed_visit_another_user )
+
+

--- a/spec/factories/cap_employees.rb
+++ b/spec/factories/cap_employees.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :cap_employee do
+    name { Faker::StarWars.character }
+    last_name { Faker::StarWars.droid }
+    cuil { Faker::StarWars.vehicle }
+    sector { Faker::StarWars.planet }
+    cap_result
+  end
+end

--- a/spec/factories/cap_results.rb
+++ b/spec/factories/cap_results.rb
@@ -1,9 +1,7 @@
 FactoryGirl.define do
   factory :cap_result do
     topic { Faker::Yoda.quote }
-    attendees_count { Faker::Number.number(2) }
     used_materials { Faker::ChuckNorris.fact }
     delivered_materials { Faker::ChuckNorris.fact }
-    cap_employee
   end
 end

--- a/spec/factories/cap_results.rb
+++ b/spec/factories/cap_results.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :cap_result do
+    topic { Faker::Yoda.quote }
+    attendees_count { Faker::Number.number(2) }
+    used_materials { Faker::ChuckNorris.fact }
+    delivered_materials { Faker::ChuckNorris.fact }
+    cap_employee
+  end
+end

--- a/spec/models/cap_employee_spec.rb
+++ b/spec/models/cap_employee_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe CapEmployee, type: :model do
+  it { should validate_presence_of(:name) }
+  it { should validate_presence_of(:last_name) }
+  it { should validate_presence_of(:cuil) }
+  it { should validate_presence_of(:cap_result_id) }
+end

--- a/spec/models/cap_result_spec.rb
+++ b/spec/models/cap_result_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe CapResult, type: :model do
+  it { should validate_presence_of(:task) }
+  it { should validate_presence_of(:topic) }
+  it { should validate_presence_of(:attendees_count) }
+end

--- a/spec/models/cap_result_spec.rb
+++ b/spec/models/cap_result_spec.rb
@@ -3,5 +3,4 @@ require 'rails_helper'
 RSpec.describe CapResult, type: :model do
   it { should validate_presence_of(:task) }
   it { should validate_presence_of(:topic) }
-  it { should validate_presence_of(:attendees_count) }
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -23,9 +23,49 @@ RSpec.describe Task, type: :model do
     end
 
     context 'without completed_at date' do
-      subject { create(:task, visit: visit, status: 'completed') }
+      subject { create(:task, visit: visit, status: 'completed', task_type: :cap) }
       it 'returns an error' do
         expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+    context 'its a cap task' do
+      create(:task, visit: visit, status: 'pending', task_type: :cap )
+      context 'and have not a cap result' do
+        subject { create(:task, visit: visit, status: 'completed', task_type: :cap, completed_at: Faker::Date.forward ) }
+        it 'returns an error' do
+          expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+      context 'and have a cap result without attendees' do
+          let(:task) { create(:task, visit: visit, status: 'completed', task_type: :cap, completed_at: Faker::Date.forward ) }
+          let(:cap_result) { create(:cap_result, task: task, attendees_count: 0) }
+          subject do
+        end
+        it 'returns an error' do
+          expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+      context 'and have a cap result with attendees' do
+        subject do
+          let(:task) { create(:task, visit: visit, status: 'completed', task_type: :cap, completed_at: Faker::Date.forward ) }
+          let(:cap_result) { create(:cap_result, task: task, attendees_count: 1) }
+        end
+        context ' but have not the same number of employees' do
+          it 'returns an error' do
+            expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+          end
+        end
+        context ' and have the same number of employees' do
+          subject do
+            let(:task) { create(:task, visit: visit, status: 'completed', task_type: :cap, completed_at: Faker::Date.forward ) }
+            let(:cap_result) { create(:cap_result, task: task, attendees_count: 1) }
+            let(:cap_employee) { create(:cap_employee, cap_result: cap_result) }
+          end
+          it 'returns ok' do
+            byebug
+            expect { subject }.to change { Task.count }.by(+1)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Se agregan los modelos para persistir el formulario de capacitación. Modelos:
Cap Result -> Resultado general de la tareas.
Cap Employees -> Listado de usuarios que asistieron a la capacitación.

Se agrega método que completa a una tarea de cap y sus validaciones correspondientes.

## Trello Card

https://trello.com/c/fURcb7g1/52-crear-modelo-formulario-de-capacitaci%C3%B3n
