### PR TITLE
Se agrega endpoint visit#complete

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,7 @@ Style/FrozenStringLiteralComment:
 
 Metrics/BlockLength:
   ExcludedMethods: ['describe', 'context', 'register']
+
+# Allow classes longer than 100 lines of code
+ClassLength:
+  Max: 250

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,6 +6,10 @@ class Task < ApplicationRecord
   enum task_type: [:cap, :rgrl, :rar], _prefix: true
   validate :validate_values
 
+  def completed?
+    status_completed?
+  end
+
   private
 
   def validate_values

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   resources :visits, only: [:index, :show] do
     post :assignment, to: 'visits#assign'
     put :remotion, to: 'visits#remove_assignment'
+    put :complete, to: 'visits#complete'
   end
   resources :institutions, only: [:show]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   resources :visits, only: [:index, :show] do
     post :assignment, to: 'visits#assign'
     put :remotion, to: 'visits#remove_assignment'
-    put :complete, to: 'visits#complete'
+    put :completion, to: 'visits#complete'
   end
   resources :institutions, only: [:show]
 

--- a/spec/controllers/visits_controller_spec.rb
+++ b/spec/controllers/visits_controller_spec.rb
@@ -200,8 +200,8 @@ describe VisitsController, type: :controller do
           expect(response.response_code).to eq 302
         end
         it 'responds with an alarm' do
-          expect(response.flash.alert).to eq 'La visita no esta en estado: pendiente,' \
-            ' El usuario y la visita tienen diferente zona'
+          expect(response.flash.alert).to eq 'La visita debe estar en estado pendiente '\
+          'and EL usuario y la visita deben tener la misma zona'
         end
       end
     end
@@ -256,7 +256,7 @@ describe VisitsController, type: :controller do
           put :complete, params: { visit_id: assigned_visit.id, completed_at: completed_at }
         end
         it 'responds with and not_modified status' do
-          expect(response).to have_http_status(:not_modified)
+          expect(response).to have_http_status(:unprocessable_entity)
         end
       end
       context 'and has all the tasks completed' do

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -52,10 +52,11 @@ describe Visit, type: :model do
   end
 
   context 'when the visit is completed' do
-    context 'without completed_at date' do
-      let(:user) { create(:user, :preventor) }
-      subject { create(:visit, user: user, status: 'completed') }
+    let(:user) { create(:user, :preventor) }
+    let(:institution) { create(:institution, zone: user.zone) }
 
+    context 'without completed_at date' do
+      subject { create(:visit, user: user, status: 'completed') }
       it 'returns an error' do
         expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
       end


### PR DESCRIPTION
validaciones:
-que se envíe la fecha de finalización por parámetro.
-que todas las tareas de la visita esten finalizadas.

El campo observaciones es opcional en el put

## Trello Card

https://trello.com/c/RAP9fxTq/51-endpoint-persistencia-formulario-de-visita
