### PR TITLE
Se agrega modelo CapResult y Attendees

### DIFF
--- a/app/models/attendee.rb
+++ b/app/models/attendee.rb
@@ -1,0 +1,4 @@
+class Attendee < ApplicationRecord
+  belongs_to :cap_result
+  validates :name, :last_name, :cuil, :cap_result_id, presence: true
+end

--- a/app/models/cap_result.rb
+++ b/app/models/cap_result.rb
@@ -1,0 +1,13 @@
+class CapResult < ApplicationRecord
+  has_one :task, as: :result
+  has_many :attendees
+  validates :topic, :task, presence: true
+
+  def valid_result?
+    attendees.size.positive?
+  end
+
+  def attendees_count
+    attendees.size
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,19 +1,35 @@
 class Task < ApplicationRecord
   belongs_to :visit
+  belongs_to :result, polymorphic: true
 
   validates :status, :task_type, :visit, presence: true
   enum status: [:pending, :completed], _prefix: true
   enum task_type: [:cap, :rgrl, :rar], _prefix: true
-  validate :validate_values
+  validate :validate_pending_values, :validate_completed_values
+
+  def complete(completed_at)
+    update_attributes!(status: 'completed', completed_at: completed_at)
+  end
 
   private
 
-  def validate_values
-    return if valid_values?
-    errors.add('invalid_task', 'Invalid completed_at for the status')
+  def validate_pending_values
+    return unless status_pending? && completed_at.present?
+    errors.add(:invalid, 'La tarea no puede tener fecha \
+      de finalización si se encuentra pendiente')
   end
 
-  def valid_values?
-    status_pending? ? completed_at.blank? : completed_at.present?
+  def validate_completed_values
+    return unless status_completed?
+    errors.add(:invalid, 'La tarea completada debe tener fecha de finalización') unless
+        completed_at.present?
+    validate_result
+  end
+
+  def validate_result
+    return errors.add(:invalid, 'La tarea completada debe tener un resultado') unless
+        result.present?
+    errors.add(:invalid, 'La tarea completada debe tener al menos un empleado') unless
+        result.valid_result?
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -21,15 +21,11 @@ class Task < ApplicationRecord
 
   def validate_completed_values
     return unless status_completed?
-    errors.add(:invalid, 'La tarea completada debe tener fecha de finalización') unless
+    errors.add(:base, 'La tarea completada debe tener fecha de finalización') unless
         completed_at.present?
-    validate_result
-  end
-
-  def validate_result
-    return errors.add(:invalid, 'La tarea completada debe tener un resultado') unless
+    return errors.add(:base, 'La tarea completada debe tener un resultado') unless
         result.present?
-    errors.add(:invalid, 'La tarea completada debe tener al menos un empleado') unless
+    errors.add(:base, 'La tarea completada debe tener al menos un empleado') unless
         result.valid_result?
   end
 end

--- a/db/migrate/20170922001044_add_result_reference_to_task.rb
+++ b/db/migrate/20170922001044_add_result_reference_to_task.rb
@@ -1,0 +1,12 @@
+class AddResultReferenceToTask < ActiveRecord::Migration[5.0]
+  def up
+    change_table :tasks do |t|
+      t.references :result, polymorphic: true
+    end
+  end
+  def down
+    change_table :tasks do |t|
+      t.remove_references :result, polymorphic: true
+    end
+  end
+end

--- a/db/migrate/20170922003345_create_cap_results.rb
+++ b/db/migrate/20170922003345_create_cap_results.rb
@@ -1,0 +1,12 @@
+class CreateCapResults < ActiveRecord::Migration[5.0]
+  def change
+    create_table :cap_results do |t|
+      t.string :topic, null: false
+      t.string :used_materials
+      t.string :coordinators
+      t.string :delivered_materials
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170922011135_create_attendees.rb
+++ b/db/migrate/20170922011135_create_attendees.rb
@@ -1,0 +1,13 @@
+class CreateAttendees < ActiveRecord::Migration[5.0]
+  def change
+    create_table :attendees do |t|
+      t.string :name, null: false
+      t.string :last_name, null: false
+      t.string :cuil, null: false
+      t.string :sector
+      t.references :cap_result, foreign_key: true, null: false
+      t.timestamps
+    end
+    add_index :attendees, [:cuil, :cap_result_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170917045838) do
+ActiveRecord::Schema.define(version: 20170922011135) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,27 @@ ActiveRecord::Schema.define(version: 20170917045838) do
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  create_table "attendees", force: :cascade do |t|
+    t.string   "name",          null: false
+    t.string   "last_name",     null: false
+    t.string   "cuil",          null: false
+    t.string   "sector"
+    t.integer  "cap_result_id", null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.index ["cap_result_id"], name: "index_attendees_on_cap_result_id", using: :btree
+    t.index ["cuil", "cap_result_id"], name: "index_attendees_on_cuil_and_cap_result_id", unique: true, using: :btree
+  end
+
+  create_table "cap_results", force: :cascade do |t|
+    t.string   "topic",               null: false
+    t.string   "used_materials"
+    t.string   "coordinators"
+    t.string   "delivered_materials"
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
+  end
+
   create_table "institutions", force: :cascade do |t|
     t.string   "name",                           null: false
     t.string   "cuit",                           null: false
@@ -76,6 +97,9 @@ ActiveRecord::Schema.define(version: 20170917045838) do
     t.integer  "visit_id",                 null: false
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
+    t.string   "result_type"
+    t.integer  "result_id"
+    t.index ["result_type", "result_id"], name: "index_tasks_on_result_type_and_result_id", using: :btree
     t.index ["visit_id"], name: "index_tasks_on_visit_id", using: :btree
   end
 
@@ -125,6 +149,7 @@ ActiveRecord::Schema.define(version: 20170917045838) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "attendees", "cap_results"
   add_foreign_key "institutions", "zones"
   add_foreign_key "tasks", "visits"
   add_foreign_key "users", "zones"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,10 +43,25 @@ completed_visit_another_user = Visit.create!(institution: another_institution, u
                                              status: :completed, priority: 4, to_visit_on: Date.yesterday,
                                              completed_at: Date.yesterday, observations: 'Se observa humedad en el area de trabajo')
 
+#Visits and tasks CAP
+assigned_visit_cap = Visit.create!(institution: institution, user: preventor_user, status: :assigned, priority: 9,
+                                   to_visit_on: Date.today)
+pending_visit_cap = Visit.create!(institution: institution, status: :pending, priority: 8)
+assigned_visit_cap_2 = Visit.create!(institution: institution, user: preventor_user, status: :assigned, priority: 9,
+                                     to_visit_on: Date.today)
+
+completed_cap_task = Task.create!(task_type: :cap, status: :pending, visit: assigned_visit_cap )
+cap_result = CapResult.create!(task: completed_cap_task, topic: 'Optimización de Salidas de emergencia' )
+Attendee.create!(name:'Julian', last_name:'Alvarez', cuil:'23-12345621-6', sector: 'Seguridad e higiene', cap_result: cap_result)
+completed_cap_task.complete(DateTime.yesterday)
+
+completed_cap_task_2 = Task.create!(task_type: :cap, status: :pending, visit: assigned_visit_cap_2 )
+cap_result_2 = CapResult.create!(task: completed_cap_task_2, topic: 'Como aprobar proyecto?' )
+Attendee.create!(name:'Tomas', last_name:'Capuccio', cuil:'23-123235621-6', sector: '5to año utn frba', cap_result: cap_result_2)
+completed_cap_task_2.complete(DateTime.yesterday)
+
+Task.create!(task_type: :cap, status: :pending, visit: pending_visit_cap )
+
 # Tasks
 Task.create!(task_type: :rgrl, status: :pending, visit: pending_visit )
 Task.create!(task_type: :rgrl, status: :pending, visit: assigned_visit )
-Task.create!(task_type: :cap, status: :completed, completed_at:Date.yesterday,  visit: completed_visit )
-Task.create!(task_type: :rgrl, status: :completed, completed_at:Date.yesterday, visit: completed_visit )
-Task.create!(task_type: :rgrl, status: :completed, completed_at:Date.yesterday, visit: completed_visit_another_user )
-Task.create!(task_type: :cap, status: :completed, completed_at:Date.yesterday, visit: completed_visit_another_user )

--- a/spec/factories/attendees.rb
+++ b/spec/factories/attendees.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :attendee do
+    name { Faker::StarWars.character }
+    last_name { Faker::StarWars.droid }
+    cuil { Faker::StarWars.vehicle }
+    sector { Faker::StarWars.planet }
+    cap_result
+  end
+end

--- a/spec/factories/cap_results.rb
+++ b/spec/factories/cap_results.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :cap_result do
+    topic { Faker::Yoda.quote }
+    used_materials { Faker::ChuckNorris.fact }
+    coordinators { Faker::StarWars.character }
+    delivered_materials { Faker::ChuckNorris.fact }
+  end
+end

--- a/spec/models/attendee_spec.rb
+++ b/spec/models/attendee_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Attendee, type: :model do
+  it { should validate_presence_of(:name) }
+  it { should validate_presence_of(:last_name) }
+  it { should validate_presence_of(:cuil) }
+  it { should validate_presence_of(:cap_result_id) }
+end

--- a/spec/models/cap_result_spec.rb
+++ b/spec/models/cap_result_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe CapResult, type: :model do
+  it { should validate_presence_of(:task) }
+  it { should validate_presence_of(:topic) }
+end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -21,11 +21,41 @@ RSpec.describe Task, type: :model do
     let!(:visit) do
       create(:visit, :completed, user: user)
     end
-
     context 'without completed_at date' do
       subject { create(:task, visit: visit, status: 'completed') }
       it 'returns an error' do
         expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+    context 'its a cap task' do
+      let!(:task) { create(:task, visit: visit, status: 'pending', task_type: :cap) }
+      let!(:completed_at) { DateTime.current }
+    end
+    context 'its a cap task' do
+      let!(:task) { create(:task, visit: visit, status: 'pending', task_type: :cap) }
+      let!(:completed_at) { DateTime.current }
+      context 'and have not a cap result' do
+        it 'returns an error' do
+          expect { task.complete(completed_at) }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+      context ', have a cap result without employees' do
+        let!(:cap_result) { create(:cap_result, task: task) }
+        it 'returns an error' do
+          expect { task.complete(completed_at) }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+      context ', have a cap result with employees' do
+        let!(:cap_result) { create(:cap_result, task: task) }
+        let!(:attendee) { create(:attendee, cap_result: cap_result) }
+        it 'returns ok. change the status ' do
+          expect { task.complete(completed_at) }.to change { task.status }
+            .from('pending').to('completed')
+        end
+        it 'and complete the completed_at date' do
+          expect { task.complete(completed_at) }.to change { task.completed_at }
+            .from(nil).to(completed_at)
+        end
       end
     end
   end


### PR DESCRIPTION
El resultado en la tarea es polimorfíco. Aclaro que quedó chota la relación en tarea (belongs_to result), pero no hay forma de hacerlo inversamente y sacando cuando se lo lee, cumple con las funciones correspondientes.

Info de polimorfismo: https://launchschool.com/blog/understanding-polymorphic-associations-in-rails

Agregue una lista de attendees a la capacitacíón. Veo mas simple trabajar por separado el registros de estos y los de riesgo.

Se eliminaron de los seeds dos tareas rgrl completas, ya que no pasan la validación de tener un resultado por no estar el modelo implementado.

## Trello Card

https://trello.com/c/fURcb7g1/52-crear-modelo-formulario-de-capacitaci%C3%B3n
